### PR TITLE
Adds docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+# Welcome to Wordpress meets Composer
+
+You can install this plugin from the [Wordpress-Plugin-Directory](https://plugins.wordpress.org/wp_talkToComposer) 
+as any other wordpress-plugin.
+
+It will create two files in your main wordpress-directory:
+
+* composer.json Your main file that allows you to use composer 
+* composer.lock The file that stores the actual version s of the plugins and themes you are using 


### PR DESCRIPTION
After merging this PR we can set the ```docs```-folder as base for documentation being available via https://wordpresstalktocomposer.github.io/wp_talktocomposer